### PR TITLE
Add 2025 model

### DIFF
--- a/api.R
+++ b/api.R
@@ -56,6 +56,12 @@ valid_runs <- rbind(
     year = "2024",
     dvc_bucket = dvc_bucket_post_2024,
     predictors_only = TRUE
+  ),
+  c(
+    run_id = "2025-02-11-charming-eric",
+    year = "2025",
+    dvc_bucket = dvc_bucket_post_2024,
+    predictors_only = TRUE
   )
 ) %>%
   as_tibble()


### PR DESCRIPTION
This PR adds the final 2025 res model to the list of valid runs available in the API.

Once this PR is merged, we can update the env var that specifies the default model to point to this run ID.

## Deployment plan

- [ ] Merge PR
- [ ] Pull the latest image on the server
- [ ] Update `AWS_S3_DEFAULT_MODEL_RUN_ID` in `.env` to point to 2025 model run ID
- [ ] Restart the Compose process
- [ ] Test the `/predict` and `/predict/<run_id>` endpoints to confirm that the new model works