### PR TITLE
Switch to Docker-native `.env` file management

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+CCAO_REGISTRY_URL=ghcr.io/ccao-data
+AWS_S3_MODEL_BUCKET=s3://ccao-model-results-us-east-1
+AWS_S3_DEFAULT_MODEL_RUN_ID=2025-02-11-charming-eric
+API_PORT=3636

--- a/api.R
+++ b/api.R
@@ -23,7 +23,6 @@ if (file.exists("/run/secrets/ENV_FILE")) {
 } else if (file.exists("secrets/ENV_FILE")) {
   readRenviron("secrets/ENV_FILE")
 }
-readRenviron(".env")
 
 # Get the model run attributes at runtime from env vars
 run_bucket <- Sys.getenv("AWS_S3_MODEL_BUCKET")

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -7,10 +7,7 @@ services:
       - "${API_PORT}:${API_PORT}"
     networks:
       - api-res-avm-net
-    environment:
-      - AWS_S3_MODEL_BUCKET
-      - AWS_S3_DEFAULT_MODEL_RUN_ID
-      - API_PORT
+    env_file: .env
     secrets:
       - ENV_FILE
     restart: unless-stopped


### PR DESCRIPTION
Our current approach to managing `.env` files is difficult to deploy, because we don't keep the `.env` file under version control (and so can't build it into the image in GitHub Actions) but we also don't mount it into the container at runtime using the [Docker-native `env_file` config attribute](https://docs.docker.com/reference/compose-file/services/#env_file). Instead, we load the `.env` file using a `readEnviron` call in `api.R`:

https://github.com/ccao-data/api-res-avm/blob/0b610fdb050833587f8bd2ac81866062fdeeaa04/api.R#L26

This makes deployment difficult, because the service will error out on this `readEnviron` call if you try to run the image that we build in GitHub Actions. Instead, we have to rebuild the image on the server every time we want to deploy, which can take a long time if the layers aren't all cached.

This PR switches our Docker Compose config to use the `env_file` attribute for a more intuitive deployment config. Using this attribute will allow us to deploy containers using images that we build in GitHub Actions.