### PR TITLE
Add 2026 final res model, make it the new default, and fix pre-commit R hooks

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
 CCAO_REGISTRY_URL=ghcr.io/ccao-data
 AWS_S3_MODEL_BUCKET=s3://ccao-model-results-us-east-1
-AWS_S3_DEFAULT_MODEL_RUN_ID=2025-02-11-charming-eric
+AWS_S3_DEFAULT_MODEL_RUN_ID=2026-02-11-recursing-rob
 API_PORT=3636

--- a/.lintr
+++ b/.lintr
@@ -1,6 +1,8 @@
 linters: linters_with_defaults(
     object_name_linter = NULL,
     object_usage_linter = NULL,
-    object_length_linter = NULL
+    object_length_linter = NULL,
+    return_linter = NULL,
+    pipe_consistency_linter(c("auto"))
   )
 encoding: "UTF-8"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # R specific hooks: https://github.com/lorenzwalthert/precommit
 repos:
 -   repo: https://github.com/lorenzwalthert/precommit
-    rev: v0.4.2
+    rev: v0.4.3.9021
     hooks:
     -   id: style-files
         args: [--style_pkg=styler, --style_fun=tidyverse_style]

--- a/api.R
+++ b/api.R
@@ -61,6 +61,12 @@ valid_runs <- rbind(
     year = "2025",
     dvc_bucket = dvc_bucket_post_2024,
     predictors_only = TRUE
+  ),
+  c(
+    run_id = "2026-02-11-recursing-rob",
+    year = "2026",
+    dvc_bucket = dvc_bucket_post_2024,
+    predictors_only = TRUE
   )
 ) %>%
   as_tibble()


### PR DESCRIPTION
This PR makes a few changes to round out the 2026 modeling season:

- Adds the 2026 final res model as a valid run ID
- Sets the 2026 final res model to the default model for the `/predict` endpoint
- Updates our pre-commit R hooks to fix conflicts between the latest version of R and the old versions of the hooks that this repo has been running

These changes are already deployed to prod, so this PR is just intended to make sure they get persisted to the main branch.